### PR TITLE
Minor documentation modifications for discrimination: Adding required checkpoint path and explicit parameter counts.

### DIFF
--- a/discrimination/README.md
+++ b/discrimination/README.md
@@ -11,16 +11,18 @@ Here are links to the discrimination checkpoints. You'll need to use google clou
 
 In other words, if you want to mimic my experimental setup, but with your own generator, you'd also need to train your own discriminator from scratch. Alternatively, if you want a really good discriminator against my checkpoints for whatever reason, you'd also probably want to train your own discriminator from scratch.
 
-Medium trained on medium, top-p=0.96:
+Medium trained on medium (355M parameters), top-p=0.96:
 ```
 gs://grover-models/discrimination/generator=medium~discriminator=grover~discsize=medium~dataset=p=0.96/model.ckpt-1562.data-00000-of-00001
 gs://grover-models/discrimination/generator=medium~discriminator=grover~discsize=medium~dataset=p=0.96/model.ckpt-1562.index
 gs://grover-models/discrimination/generator=medium~discriminator=grover~discsize=medium~dataset=p=0.96/model.ckpt-1562.meta
+gs://grover-models/discrimination/generator=medium~discriminator=grover~discsize=medium~dataset=p=0.96/checkpoint
 ```
 
-Mega trained on mega, top-p=0.94:
+Mega trained on mega (1.5B parameters), top-p=0.94:
 ```
 gs://grover-models/discrimination/generator=mega~discriminator=grover~discsize=mega~dataset=p=0.94/model.ckpt-1562.data-00000-of-00001
 gs://grover-models/discrimination/generator=mega~discriminator=grover~discsize=mega~dataset=p=0.94/model.ckpt-1562.index
 gs://grover-models/discrimination/generator=mega~discriminator=grover~discsize=mega~dataset=p=0.94/model.ckpt-1562.meta
+gs://grover-models/discrimination/generator=mega~discriminator=grover~discsize=mega~dataset=p=0.94/checkpoint
 ```


### PR DESCRIPTION
Hey Rowan, thanks for the awesome repo.

I was just running through `run_discriminator.py` with the prebuilt models and noticed a couple minor issues in the discrimination documentation.

1. The code is checking explicitly for the for the "checkpoint" file (and will fail without it), but these aren't listed for download in the discrimination README.  I've added the GCS URL for the corresponding checkpoint for each model.

2. The discrimination README refers to Grover "medium", while the paper refers to Grover "large".  This isn't a big deal (it's analogous to GPT-2 "medium", so I understand why it's referred to as "medium" here).  I did spend a bit of time trying to make sure I had the right model, so I thought it might be helpful to include the parameter counts to clarify.

Thanks again,
Evan